### PR TITLE
[K32W0] Don't specify number of LEDs or buttons in SDK unless on DK6 …

### DIFF
--- a/third_party/nxp/k32w0_sdk/k32w0_sdk.gni
+++ b/third_party/nxp/k32w0_sdk/k32w0_sdk.gni
@@ -21,7 +21,7 @@ import("${chip_root}/src/platform/nxp/k32w/k32w0/args.gni")
 declare_args() {
   # Location of the k32w0 SDK.
   k32w0_sdk_root = getenv("NXP_K32W061_SDK_ROOT")
-  chip_with_DK6 = 1
+  chip_with_DK6 = true
   chip_with_OM15082 = 0
   chip_with_ot_cli = 0
   chip_with_low_power = 0
@@ -40,7 +40,13 @@ template("k32w0_sdk") {
     k32w0_sdk_root = invoker.k32w0_sdk_root
   }
 
+  if (defined(invoker.override_is_DK6)) {
+    chip_with_DK6 = invoker.override_is_DK6
+  }
+
   assert(k32w0_sdk_root != "", "k32w0_sdk_root must be specified")
+  assert(chip_with_OM15082 == 0 || chip_with_DK6,
+      "OM15082 expansion board is only supported on DK6 board")
   assert(
       chip_with_low_power == 0 ||
           (chip_with_low_power == 1 && chip_with_OM15082 == 0 &&
@@ -60,7 +66,7 @@ template("k32w0_sdk") {
     # we will add them to cflags below instead.
     _sdk_include_dirs = []
 
-    if (chip_with_DK6 != 0) {
+    if (chip_with_DK6) {
       if (chip_with_low_power != 0) {
         _sdk_include_dirs += [
           "${k32w0_sdk_root}/boards/k32w061dk6/wireless_examples/openthread/lped/bm",
@@ -350,7 +356,7 @@ template("k32w0_sdk") {
       "${k32w0_sdk_root}/rtos/amazon-freertos/lib/FreeRTOS/timers.c",
     ]
 
-    if (chip_with_DK6 != 0) {
+    if (chip_with_DK6) {
 
       if (chip_with_low_power != 0) {
         sources += [

--- a/third_party/nxp/k32w0_sdk/k32w0_sdk.gni
+++ b/third_party/nxp/k32w0_sdk/k32w0_sdk.gni
@@ -174,12 +174,9 @@ template("k32w0_sdk") {
       "gExternalFlashIsCiphered_d=1",
       "gBootData_None_c=1",
       "PROGRAM_PAGE_SZ=256",
-      "gKeyBoardSupported_d",
       "gPdmNbSegments=63",
       "configFRTOS_MEMORY_SCHEME=4",
       "osCustomStartup=1",
-      "gLEDsOnTargetBoardCnt_c=2",
-      "gLED_InvertedMode_d=1",
       "ENABLE_RAM_VECTOR_TABLE=1",
       "gTMR_Enabled_d=1",
       "gTimestamp_Enabled_d=0",
@@ -219,13 +216,27 @@ template("k32w0_sdk") {
       ]
     }
 
-    if (chip_with_OM15082 == 1) {
-      defines += [
-        "gKBD_KeysCount_c=4",
-        "OM15082=1",
-      ]
-    } else {
-      defines += [ "gKBD_KeysCount_c=1" ]
+    if (chip_with_DK6) {
+      if (chip_with_OM15082 != 0) {
+        defines += [
+          "OM15082=1",
+          "gKeyBoardSupported_d=1",
+          "gKBD_KeysCount_c=4",
+        ]
+      } else {
+        defines += [
+          "gKeyBoardSupported_d=1",
+          "gKBD_KeysCount_c=1",
+        ]
+      }
+
+      if (chip_with_low_power == 0) {
+        defines += [
+          "gLEDSupported_d=1",
+          "gLEDsOnTargetBoardCnt_c=2",
+          "gLED_InvertedMode_d=1",
+        ]
+      }
     }
 
     if (chip_with_ot_cli == 1) {
@@ -245,9 +256,6 @@ template("k32w0_sdk") {
       ]
     } else {
       defines += [
-        "gLEDSupported_d",
-        "gLED_InvertedMode_d=1",
-        "gLEDsOnTargetBoardCnt_c=2",
         "cPWR_UsePowerDownMode=0",
         "cPWR_FullPowerDownMode=0",
       ]


### PR DESCRIPTION
The number of buttons and LEDs is hard-coded in the K32W0 SDK, but this is not appropriate for any project using a custom board.

I have made some changes which I believe fix this problem.  Please review this pull request and if it is correct and does not break any other use-case of the code merge it into the latest branch which we are working from.

