### PR TITLE
Update supported chips to K32W0x1 family

### DIFF
--- a/src/platform/nxp/k32w/k32w0/PlatformManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/PlatformManagerImpl.cpp
@@ -57,15 +57,18 @@ static int app_entropy_source(void * data, unsigned char * output, size_t len, s
 CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 {
     CHIP_ERROR err;
+    uint32_t chip_type;
 
     // Initialize the configuration system.
     err = Internal::K32WConfig::Init();
     SuccessOrExit(err);
 
-    if (Chip_GetType() != CHIP_K32W061)
+    chip_type = Chip_GetType();
+    /* Check that chip type is from K32W0x1 family: K32W041A, K32W041AM, K32W061 or K32W041 */
+    if (chip_type <= CHIP_K32W041)
     {
         err = CHIP_ERROR_INTERNAL;
-        ChipLogError(DeviceLayer, "Invalid chip type, expected K32W061");
+        ChipLogError(DeviceLayer, "Invalid chip type, expected K32W0x1");
 
         goto exit;
     }

--- a/src/platform/nxp/k32w/k32w0/PlatformManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/PlatformManagerImpl.cpp
@@ -57,15 +57,13 @@ static int app_entropy_source(void * data, unsigned char * output, size_t len, s
 CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 {
     CHIP_ERROR err;
-    uint32_t chip_type;
 
     // Initialize the configuration system.
     err = Internal::K32WConfig::Init();
     SuccessOrExit(err);
 
-    chip_type = Chip_GetType();
     /* Check that chip type is from K32W0x1 family: K32W041A, K32W041AM, K32W061 or K32W041 */
-    if (chip_type <= CHIP_K32W041)
+    if (Chip_GetType() <= CHIP_K32W041)
     {
         err = CHIP_ERROR_INTERNAL;
         ChipLogError(DeviceLayer, "Invalid chip type, expected K32W0x1");


### PR DESCRIPTION
Update supported chips to K32W0x1 family. User just needs to replace the header file with the appropriate platform file and rest of code should support the change.